### PR TITLE
Bugfix/dockerfile alpine weni

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:12-alpine as builder
 ENV WORKDIR /home/app
 WORKDIR $WORKDIR
 
-RUN apk update && apk add git yarn python
+RUN apk update && apk add git yarn
 
 COPY package.json .
 COPY yarn.lock .


### PR DESCRIPTION
Previously, **python** was the only package name in the distribution alpine.

As the base image used doesnt have the distro locked, with time alpine base distro version was changed, and in the new alpine versions the python package was separated under the names **python3** or **python2**.

So just putting **python** to install was breaking the **Dockerfile**.

But build here, the image was generated locally even without the **python** package, so i removed that package which doesnt seem to be needed anymore. 